### PR TITLE
Add label selector and config selector to AlertManagerConfig

### DIFF
--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -30,7 +30,6 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/utils/ptr"
 	cu "kmodules.xyz/client-go/client"
-	meta_util "kmodules.xyz/client-go/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,14 +46,7 @@ const (
 	inboxAPIServiceGroup = "inbox.monitoring.appscode.com"
 	amcfgInboxAgent      = "inbox-agent"
 	amcfgLabelKey        = "app.kubernetes.io/name"
-	amcfgLabelValue      = "inbox-agent"
 )
-
-var selfNamespace = meta_util.PodNamespace()
-
-var defaultPresetsLabels = map[string]string{
-	"charts.x-helm.dev/is-default-preset": "true",
-}
 
 // AlertmanagerReconciler reconciles an Alertmanager object
 type AlertmanagerReconciler struct {
@@ -113,7 +105,7 @@ func (r *AlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if am.Spec.AlertmanagerConfigSelector.MatchLabels == nil {
 		am.Spec.AlertmanagerConfigSelector.MatchLabels = make(map[string]string)
 	}
-	am.Spec.AlertmanagerConfigSelector.MatchLabels[amcfgLabelKey] = amcfgLabelValue
+	am.Spec.AlertmanagerConfigSelector.MatchLabels[amcfgLabelKey] = amcfgInboxAgent
 
 	if err := r.SetupClusterForAlertmanager(ctx, &am, apisvc); err != nil {
 		log.Error(err, "unable to setup Alertmanager config")
@@ -136,7 +128,7 @@ func (r *AlertmanagerReconciler) SetupClusterForAlertmanager(ctx context.Context
 		if obj.Labels == nil {
 			obj.Labels = make(map[string]string)
 		}
-		obj.Labels[amcfgLabelKey] = amcfgLabelValue
+		obj.Labels[amcfgLabelKey] = amcfgInboxAgent
 
 		obj.Spec.Receivers = []monitoringv1alpha1.Receiver{
 			{

--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -46,8 +46,8 @@ import (
 const (
 	inboxAPIServiceGroup = "inbox.monitoring.appscode.com"
 	amcfgInboxAgent      = "inbox-agent"
-	amcfgLabelKey        = "inbox-agent-amcfg-label"
-	amcfgLabelValue      = "inbox-agent-amcfg"
+	amcfgLabelKey        = "app"
+	amcfgLabelValue      = "inbox-agent"
 )
 
 var selfNamespace = meta_util.PodNamespace()

--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -46,6 +46,8 @@ import (
 const (
 	inboxAPIServiceGroup = "inbox.monitoring.appscode.com"
 	amcfgInboxAgent      = "inbox-agent"
+	amcfgLabelKey        = "alertmanagerConfig"
+	amcfgLabelValue      = "inbox-agent-alertmanager-config"
 )
 
 var selfNamespace = meta_util.PodNamespace()
@@ -105,6 +107,10 @@ func (r *AlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	am.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{amcfgLabelKey: amcfgLabelValue},
+	}
+
 	if err := r.SetupClusterForAlertmanager(ctx, &am, apisvc); err != nil {
 		log.Error(err, "unable to setup Alertmanager config")
 		return ctrl.Result{}, err
@@ -122,6 +128,8 @@ func (r *AlertmanagerReconciler) SetupClusterForAlertmanager(ctx context.Context
 	}
 	crvt, err := cu.CreateOrPatch(ctx, r.kc, &cr, func(in client.Object, createOp bool) client.Object {
 		obj := in.(*monitoringv1alpha1.AlertmanagerConfig)
+
+		obj.Labels = map[string]string{amcfgLabelKey: amcfgLabelValue}
 
 		obj.Spec.Receivers = []monitoringv1alpha1.Receiver{
 			{

--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -46,7 +46,7 @@ import (
 const (
 	inboxAPIServiceGroup = "inbox.monitoring.appscode.com"
 	amcfgInboxAgent      = "inbox-agent"
-	amcfgLabelKey        = "app"
+	amcfgLabelKey        = "app.kubernetes.io/name"
 	amcfgLabelValue      = "inbox-agent"
 )
 


### PR DESCRIPTION
Add labelselector to alertmanager configselector, and matching labels to alertmanager config, so we don't have to manually setup the selectors.