### PR TITLE
Add OpenShift user-workload monitoring support across Prometheus and Alertmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 Use the following manifests to enable user workload monitoring and apply a minimal namespace-scoped RBAC policy.
 
+Important notes:
+
+- Remove any custom Prometheus instances before enabling `enableUserWorkload: true`.
+- The `user-workload-monitoring-config` `ConfigMap` is typically created automatically after user workload monitoring is enabled.
+- Every save to `user-workload-monitoring-config` can trigger a rollout of user workload monitoring components.
+
 ### 1) Enable User Workload Monitoring (`cluster-monitoring-config`)
 
 ```yaml
@@ -48,7 +54,7 @@ data:
           memory: 2Gi
       volumeClaimTemplate:
         spec:
-          storageClassName: gp3-csi
+          storageClassName: <your-storage-class>
           resources:
             requests:
               storage: 50Gi
@@ -64,23 +70,13 @@ oc apply -f user-workload-monitoring-config.yaml
 
 ### 3) Minimal Namespace RBAC For Team Monitoring Objects
 
-This policy allows a team group to manage `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` only in its own namespace.
+OpenShift provides built-in monitoring cluster roles. For project-scoped monitoring object management, bind `monitoring-edit` in the target project namespace.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: user-workload-monitoring-editor
-  namespace: my-team
-rules:
-  - apiGroups: ["monitoring.coreos.com"]
-    resources: ["servicemonitors", "podmonitors", "prometheusrules"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: user-workload-monitoring-editor
+  name: monitoring-edit
   namespace: my-team
 subjects:
   - kind: Group
@@ -88,12 +84,20 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: user-workload-monitoring-editor
+  kind: ClusterRole
+  name: monitoring-edit
 ```
 
 Apply:
 
 ```bash
 oc apply -f my-team-monitoring-rbac.yaml
+```
+
+Optional: allow a non-admin user to tune user workload monitoring config in `openshift-user-workload-monitoring`:
+
+```bash
+oc -n openshift-user-workload-monitoring adm policy add-role-to-user \
+  user-workload-monitoring-config-edit <username> \
+  --role-namespace openshift-user-workload-monitoring
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Apply:
 oc apply -f cluster-monitoring-config.yaml
 ```
 
+Verify user workload monitoring components are running:
+
+```bash
+oc -n openshift-user-workload-monitoring get pod
+```
+
+Expected components include `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload`.
+
 ### 2) Configure User Workload Stack (`user-workload-monitoring-config`)
 
 ```yaml
@@ -101,3 +109,39 @@ oc -n openshift-user-workload-monitoring adm policy add-role-to-user \
   user-workload-monitoring-config-edit <username> \
   --role-namespace openshift-user-workload-monitoring
 ```
+
+### 4) Optional Alert Routing Setup For User Projects
+
+Enable one of the following patterns:
+
+- Platform Alertmanager integration (`cluster-monitoring-config`):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    alertmanagerMain:
+      enableUserAlertmanagerConfig: true
+```
+
+- Dedicated user Alertmanager (`user-workload-monitoring-config`):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    alertmanager:
+      enabled: true
+      enableAlertmanagerConfig: true
+```
+
+Then bind `alert-routing-edit` in each user project namespace where users should manage `AlertmanagerConfig` resources.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,97 @@
 [![Twitter](https://img.shields.io/twitter/follow/OpenViz.svg?style=social&logo=twitter&label=Follow)](https://twitter.com/intent/follow?screen_name=OpenViz)
 
 # Grafana Operator
+
+## OpenShift 4.21 User Workload Monitoring
+
+Use the following manifests to enable user workload monitoring and apply a minimal namespace-scoped RBAC policy.
+
+### 1) Enable User Workload Monitoring (`cluster-monitoring-config`)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+```
+
+Apply:
+
+```bash
+oc apply -f cluster-monitoring-config.yaml
+```
+
+### 2) Configure User Workload Stack (`user-workload-monitoring-config`)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      retention: 15d
+      resources:
+        requests:
+          cpu: 200m
+          memory: 1Gi
+        limits:
+          cpu: 1
+          memory: 2Gi
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3-csi
+          resources:
+            requests:
+              storage: 50Gi
+    thanosRuler:
+      retention: 24h
+```
+
+Apply:
+
+```bash
+oc apply -f user-workload-monitoring-config.yaml
+```
+
+### 3) Minimal Namespace RBAC For Team Monitoring Objects
+
+This policy allows a team group to manage `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` only in its own namespace.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: user-workload-monitoring-editor
+  namespace: my-team
+rules:
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["servicemonitors", "podmonitors", "prometheusrules"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user-workload-monitoring-editor
+  namespace: my-team
+subjects:
+  - kind: Group
+    name: my-team-developers
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: user-workload-monitoring-editor
+```
+
+Apply:
+
+```bash
+oc apply -f my-team-monitoring-rbac.yaml
+```

--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -46,6 +46,9 @@ const (
 	inboxAPIServiceGroup = "inbox.monitoring.appscode.com"
 	amcfgInboxAgent      = "inbox-agent"
 	amcfgLabelKey        = "app.kubernetes.io/name"
+
+	OpenShiftUserWorkloadNamespace    = "openshift-user-workload-monitoring"
+	OpenShiftUserWorkloadAlertmanager = "alertmanager-user-workload"
 )
 
 // AlertmanagerReconciler reconciles an Alertmanager object
@@ -88,6 +91,20 @@ func (r *AlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if ready, err := r.d.Ready(); !ready {
 		return ctrl.Result{}, err
+	}
+
+	key := req.NamespacedName
+	isDefault := r.d.IsDefault(key)
+	if r.d.OpenShiftManaged() {
+		if am.Namespace == OpenShiftUserWorkloadNamespace && am.Name == OpenShiftUserWorkloadAlertmanager {
+			isDefault = true
+		} else {
+			// On OpenShift, only reconcile user-workload Alertmanager for this controller.
+			return ctrl.Result{}, nil
+		}
+		if !isDefault {
+			return ctrl.Result{}, nil
+		}
 	}
 
 	if am.DeletionTimestamp != nil {

--- a/pkg/controllers/prometheus/prometheus_controller.go
+++ b/pkg/controllers/prometheus/prometheus_controller.go
@@ -58,6 +58,9 @@ const (
 	ServiceAccountTrickster = "trickster"
 	CRTrickster             = "appscode:trickster:proxy"
 
+	OpenShiftUserWorkloadNamespace  = "openshift-user-workload-monitoring"
+	OpenShiftUserWorkloadPrometheus = "user-workload"
+
 	RegisteredKey        = mona.GroupName + "/registered"
 	tokenIDKey           = mona.GroupName + "/token-id"
 	presetsMonitoring    = "monitoring-presets"
@@ -128,6 +131,12 @@ func (r *PrometheusReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	key := req.NamespacedName
 	isDefault := r.d.IsDefault(key)
+	if r.d.OpenShiftManaged() &&
+		prom.Namespace == OpenShiftUserWorkloadNamespace &&
+		prom.Name == OpenShiftUserWorkloadPrometheus {
+		// On OpenShift, user-workload Prometheus is the tenant-facing stack.
+		isDefault = true
+	}
 
 	if prom.DeletionTimestamp != nil {
 		err := r.CleanupPreset(&prom, isDefault)
@@ -136,7 +145,7 @@ func (r *PrometheusReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		var projectId string
-		if !isDefault {
+		if r.d.Federated() && !isDefault {
 			_, projectId, err = r.NamespaceForProjectSettings(&prom)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -392,7 +401,7 @@ func (r *PrometheusReconciler) SetupClusterForPrometheus(ctx context.Context, pr
 		(rb.Annotations[RegisteredKey] != state ||
 			(rancherToken != nil && rb.Annotations[tokenIDKey] != rancherToken.TokenID)) {
 		var projectId string
-		if !isDefault {
+		if r.d.Federated() && !isDefault {
 			_, projectId, err = r.NamespaceForProjectSettings(prom)
 			if err != nil {
 				return err
@@ -431,6 +440,11 @@ func (r *PrometheusReconciler) SetupClusterForPrometheus(ctx context.Context, pr
 }
 
 func (r *PrometheusReconciler) CreatePreset(p *monitoringv1.Prometheus, isDefault bool) error {
+	if r.d.OpenShiftManaged() && !isDefault {
+		// Avoid overwriting cluster-scoped preset from OpenShift's non user-workload Prometheus.
+		return nil
+	}
+
 	presets := r.GeneratePresetForPrometheus(*p, isDefault)
 	presetBytes, err := json.Marshal(presets)
 	if err != nil {
@@ -573,7 +587,9 @@ func (r *PrometheusReconciler) GeneratePresetForPrometheus(p monitoringv1.Promet
 		klog.Warningf("Prometheus %s/%s uses match expressions in ServiceMonitorSelector", p.Namespace, p.Name)
 	}
 	if len(svcmonLabels) == 0 {
-		if isDefault && r.d.RancherManaged() {
+		if r.d.OpenShiftManaged() {
+			svcmonLabels = map[string]string{}
+		} else if isDefault && r.d.RancherManaged() {
 			svcmonLabels = defaultRancherMonitoringLabels
 		} else {
 			svcmonLabels = defaultPrometheusStackLabels
@@ -587,7 +603,9 @@ func (r *PrometheusReconciler) GeneratePresetForPrometheus(p monitoringv1.Promet
 		klog.Warningf("Prometheus %s/%s uses match expressions in RuleSelector", p.Namespace, p.Name)
 	}
 	if len(ruleLabels) == 0 {
-		if isDefault && r.d.RancherManaged() {
+		if r.d.OpenShiftManaged() {
+			ruleLabels = map[string]string{}
+		} else if isDefault && r.d.RancherManaged() {
 			ruleLabels = defaultRancherMonitoringLabels
 		} else {
 			ruleLabels = defaultPrometheusStackLabels

--- a/pkg/detector/alertmanager.go
+++ b/pkg/detector/alertmanager.go
@@ -38,6 +38,7 @@ var GVKAlertmanager = schema.GroupVersionKind{
 type AlertmanagerDetector interface {
 	Ready() (bool, error)
 	RancherManaged() bool
+	OpenShiftManaged() bool
 	Federated() bool
 	IsDefault(key types.NamespacedName) bool
 }
@@ -49,6 +50,7 @@ func NewAlertmanagerDetector(kc client.Client) AlertmanagerDetector {
 type lazyAlertmanager struct {
 	kc        client.Client
 	delegated AlertmanagerDetector
+	openShift bool
 	mu        sync.Mutex
 }
 
@@ -64,6 +66,8 @@ func (l *lazyAlertmanager) detect() error {
 	if len(list.Items) == 0 {
 		return errUnknown
 	}
+
+	l.openShift = clustermeta.IsOpenShiftManaged(l.kc.RESTMapper())
 
 	if clustermeta.IsRancherManaged(l.kc.RESTMapper()) {
 		for _, obj := range list.Items {
@@ -112,6 +116,15 @@ func (l *lazyAlertmanager) Federated() bool {
 	return l.delegated.Federated()
 }
 
+func (l *lazyAlertmanager) OpenShiftManaged() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.delegated == nil {
+		panic("NotReady")
+	}
+	return l.openShift
+}
+
 func (l *lazyAlertmanager) IsDefault(key types.NamespacedName) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -131,6 +144,10 @@ func (f federatedAlertmanager) Ready() (bool, error) {
 
 func (f federatedAlertmanager) RancherManaged() bool {
 	return true
+}
+
+func (f federatedAlertmanager) OpenShiftManaged() bool {
+	return false
 }
 
 func (f federatedAlertmanager) Federated() bool {
@@ -155,6 +172,10 @@ func (s standaloneAlertmanager) Ready() (bool, error) {
 
 func (s standaloneAlertmanager) RancherManaged() bool {
 	return s.rancher
+}
+
+func (s standaloneAlertmanager) OpenShiftManaged() bool {
+	return false
 }
 
 func (s standaloneAlertmanager) Federated() bool {

--- a/pkg/detector/alertmanager_test.go
+++ b/pkg/detector/alertmanager_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package detector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAlertmanagerDetectorOpenShiftManaged(t *testing.T) {
+	tests := []struct {
+		name      string
+		openShift bool
+	}{
+		{name: "detects OpenShift cluster", openShift: true},
+		{name: "detects non OpenShift cluster", openShift: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapper := newAlertmanagerTestRESTMapper(tt.openShift)
+			item := unstructured.Unstructured{}
+			item.SetGroupVersionKind(GVKAlertmanager)
+			item.SetNamespace("test")
+			item.SetName("test")
+
+			kc := &alertmanagerStubClient{
+				mapper: mapper,
+				items:  []unstructured.Unstructured{item},
+			}
+
+			d := NewAlertmanagerDetector(kc)
+			ready, err := d.Ready()
+			if err != nil {
+				t.Fatalf("expected detector to become ready: %v", err)
+			}
+			if !ready {
+				t.Fatalf("expected detector to be ready")
+			}
+
+			if got := d.OpenShiftManaged(); got != tt.openShift {
+				t.Fatalf("OpenShiftManaged() = %v, want %v", got, tt.openShift)
+			}
+		})
+	}
+}
+
+func TestAlertmanagerDetectorOpenShiftManagedPanicsBeforeReady(t *testing.T) {
+	mapper := newAlertmanagerTestRESTMapper(true)
+	kc := &alertmanagerStubClient{mapper: mapper}
+
+	d := NewAlertmanagerDetector(kc)
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatalf("expected panic when OpenShiftManaged() is called before Ready()")
+		}
+		if recovered != "NotReady" {
+			t.Fatalf("panic = %v, want NotReady", recovered)
+		}
+	}()
+
+	_ = d.OpenShiftManaged()
+}
+
+func newAlertmanagerTestRESTMapper(openShift bool) meta.RESTMapper {
+	amGV := schema.GroupVersion{Group: "monitoring.coreos.com", Version: "v1"}
+	gvs := []schema.GroupVersion{amGV}
+	if openShift {
+		gvs = append(gvs, schema.GroupVersion{Group: "project.openshift.io", Version: "v1"})
+	}
+
+	mapper := meta.NewDefaultRESTMapper(gvs)
+	mapper.AddSpecific(
+		schema.GroupVersionKind{Group: amGV.Group, Version: amGV.Version, Kind: "Alertmanager"},
+		schema.GroupVersionResource{Group: amGV.Group, Version: amGV.Version, Resource: "alertmanagers"},
+		schema.GroupVersionResource{Group: amGV.Group, Version: amGV.Version, Resource: "alertmanager"},
+		meta.RESTScopeNamespace,
+	)
+
+	if openShift {
+		projectGV := schema.GroupVersion{Group: "project.openshift.io", Version: "v1"}
+		mapper.AddSpecific(
+			schema.GroupVersionKind{Group: projectGV.Group, Version: projectGV.Version, Kind: "Project"},
+			schema.GroupVersionResource{Group: projectGV.Group, Version: projectGV.Version, Resource: "projects"},
+			schema.GroupVersionResource{Group: projectGV.Group, Version: projectGV.Version, Resource: "project"},
+			meta.RESTScopeRoot,
+		)
+	}
+
+	return mapper
+}
+
+type alertmanagerStubClient struct {
+	mapper meta.RESTMapper
+	items  []unstructured.Unstructured
+}
+
+func (s *alertmanagerStubClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	ul, ok := list.(*unstructured.UnstructuredList)
+	if !ok {
+		return fmt.Errorf("unsupported list type: %T", list)
+	}
+	ul.Items = append([]unstructured.Unstructured(nil), s.items...)
+	return nil
+}
+
+func (s *alertmanagerStubClient) Apply(context.Context, runtime.ApplyConfiguration, ...client.ApplyOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) Create(context.Context, client.Object, ...client.CreateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) Delete(context.Context, client.Object, ...client.DeleteOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) Update(context.Context, client.Object, ...client.UpdateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) DeleteAllOf(context.Context, client.Object, ...client.DeleteAllOfOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubClient) Status() client.SubResourceWriter {
+	return &alertmanagerStubSubResourceClient{}
+}
+
+func (s *alertmanagerStubClient) SubResource(string) client.SubResourceClient {
+	return &alertmanagerStubSubResourceClient{}
+}
+
+func (s *alertmanagerStubClient) Scheme() *runtime.Scheme {
+	return runtime.NewScheme()
+}
+
+func (s *alertmanagerStubClient) RESTMapper() meta.RESTMapper {
+	return s.mapper
+}
+
+func (s *alertmanagerStubClient) GroupVersionKindFor(runtime.Object) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+
+func (s *alertmanagerStubClient) IsObjectNamespaced(runtime.Object) (bool, error) {
+	return true, nil
+}
+
+type alertmanagerStubSubResourceClient struct{}
+
+func (s *alertmanagerStubSubResourceClient) Get(context.Context, client.Object, client.Object, ...client.SubResourceGetOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubSubResourceClient) Create(context.Context, client.Object, client.Object, ...client.SubResourceCreateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubSubResourceClient) Update(context.Context, client.Object, ...client.SubResourceUpdateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *alertmanagerStubSubResourceClient) Patch(context.Context, client.Object, client.Patch, ...client.SubResourcePatchOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+var _ client.Client = (*alertmanagerStubClient)(nil)
+var _ client.SubResourceClient = (*alertmanagerStubSubResourceClient)(nil)

--- a/pkg/detector/prometheus.go
+++ b/pkg/detector/prometheus.go
@@ -39,6 +39,7 @@ var GVKPrometheus = schema.GroupVersionKind{
 type PrometheusDetector interface {
 	Ready() (bool, error)
 	RancherManaged() bool
+	OpenShiftManaged() bool
 	Federated() bool
 	IsDefault(key types.NamespacedName) bool
 }
@@ -52,6 +53,7 @@ var errUnknown = errors.New("unknown")
 type lazyPrometheus struct {
 	kc        client.Client
 	delegated PrometheusDetector
+	openShift bool
 	mu        sync.Mutex
 }
 
@@ -67,6 +69,8 @@ func (l *lazyPrometheus) detect() error {
 	if len(list.Items) == 0 {
 		return errUnknown
 	}
+
+	l.openShift = clustermeta.IsOpenShiftManaged(l.kc.RESTMapper())
 
 	if clustermeta.IsRancherManaged(l.kc.RESTMapper()) {
 		for _, obj := range list.Items {
@@ -115,6 +119,15 @@ func (l *lazyPrometheus) Federated() bool {
 	return l.delegated.Federated()
 }
 
+func (l *lazyPrometheus) OpenShiftManaged() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.delegated == nil {
+		panic("NotReady")
+	}
+	return l.openShift
+}
+
 func (l *lazyPrometheus) IsDefault(key types.NamespacedName) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -134,6 +147,10 @@ func (f federatedPrometheus) Ready() (bool, error) {
 
 func (f federatedPrometheus) RancherManaged() bool {
 	return true
+}
+
+func (f federatedPrometheus) OpenShiftManaged() bool {
+	return false
 }
 
 func (f federatedPrometheus) Federated() bool {
@@ -158,6 +175,10 @@ func (s standalonePrometheus) Ready() (bool, error) {
 
 func (s standalonePrometheus) RancherManaged() bool {
 	return s.rancher
+}
+
+func (s standalonePrometheus) OpenShiftManaged() bool {
+	return false
 }
 
 func (s standalonePrometheus) Federated() bool {

--- a/pkg/detector/prometheus_test.go
+++ b/pkg/detector/prometheus_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package detector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestPrometheusDetectorOpenShiftManaged(t *testing.T) {
+	tests := []struct {
+		name      string
+		openShift bool
+	}{
+		{
+			name:      "detects OpenShift cluster",
+			openShift: true,
+		},
+		{
+			name:      "detects non OpenShift cluster",
+			openShift: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapper := newTestRESTMapper(tt.openShift)
+			item := unstructured.Unstructured{}
+			item.SetGroupVersionKind(GVKPrometheus)
+			item.SetNamespace("test")
+			item.SetName("test")
+
+			kc := &stubClient{
+				mapper: mapper,
+				items:  []unstructured.Unstructured{item},
+			}
+
+			d := NewPrometheusDetector(kc)
+			ready, err := d.Ready()
+			if err != nil {
+				t.Fatalf("expected detector to become ready: %v", err)
+			}
+			if !ready {
+				t.Fatalf("expected detector to be ready")
+			}
+
+			if got := d.OpenShiftManaged(); got != tt.openShift {
+				t.Fatalf("OpenShiftManaged() = %v, want %v", got, tt.openShift)
+			}
+		})
+	}
+}
+
+func TestPrometheusDetectorOpenShiftManagedPanicsBeforeReady(t *testing.T) {
+	mapper := newTestRESTMapper(true)
+	kc := &stubClient{mapper: mapper}
+
+	d := NewPrometheusDetector(kc)
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatalf("expected panic when OpenShiftManaged() is called before Ready()")
+		}
+		if recovered != "NotReady" {
+			t.Fatalf("panic = %v, want NotReady", recovered)
+		}
+	}()
+
+	_ = d.OpenShiftManaged()
+}
+
+func newTestRESTMapper(openShift bool) meta.RESTMapper {
+	promGV := schema.GroupVersion{Group: "monitoring.coreos.com", Version: "v1"}
+	gvs := []schema.GroupVersion{promGV}
+	if openShift {
+		gvs = append(gvs, schema.GroupVersion{Group: "project.openshift.io", Version: "v1"})
+	}
+
+	mapper := meta.NewDefaultRESTMapper(gvs)
+	mapper.AddSpecific(
+		schema.GroupVersionKind{Group: promGV.Group, Version: promGV.Version, Kind: "Prometheus"},
+		schema.GroupVersionResource{Group: promGV.Group, Version: promGV.Version, Resource: "prometheuses"},
+		schema.GroupVersionResource{Group: promGV.Group, Version: promGV.Version, Resource: "prometheus"},
+		meta.RESTScopeNamespace,
+	)
+
+	if openShift {
+		projectGV := schema.GroupVersion{Group: "project.openshift.io", Version: "v1"}
+		mapper.AddSpecific(
+			schema.GroupVersionKind{Group: projectGV.Group, Version: projectGV.Version, Kind: "Project"},
+			schema.GroupVersionResource{Group: projectGV.Group, Version: projectGV.Version, Resource: "projects"},
+			schema.GroupVersionResource{Group: projectGV.Group, Version: projectGV.Version, Resource: "project"},
+			meta.RESTScopeRoot,
+		)
+	}
+
+	return mapper
+}
+
+type stubClient struct {
+	mapper meta.RESTMapper
+	items  []unstructured.Unstructured
+}
+
+func (s *stubClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	ul, ok := list.(*unstructured.UnstructuredList)
+	if !ok {
+		return fmt.Errorf("unsupported list type: %T", list)
+	}
+	ul.Items = append([]unstructured.Unstructured(nil), s.items...)
+	return nil
+}
+
+func (s *stubClient) Apply(context.Context, runtime.ApplyConfiguration, ...client.ApplyOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) Create(context.Context, client.Object, ...client.CreateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) Delete(context.Context, client.Object, ...client.DeleteOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) Update(context.Context, client.Object, ...client.UpdateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) DeleteAllOf(context.Context, client.Object, ...client.DeleteAllOfOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubClient) Status() client.SubResourceWriter {
+	return &stubSubResourceClient{}
+}
+
+func (s *stubClient) SubResource(string) client.SubResourceClient {
+	return &stubSubResourceClient{}
+}
+
+func (s *stubClient) Scheme() *runtime.Scheme {
+	return runtime.NewScheme()
+}
+
+func (s *stubClient) RESTMapper() meta.RESTMapper {
+	return s.mapper
+}
+
+func (s *stubClient) GroupVersionKindFor(runtime.Object) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+
+func (s *stubClient) IsObjectNamespaced(runtime.Object) (bool, error) {
+	return true, nil
+}
+
+type stubSubResourceClient struct{}
+
+func (s *stubSubResourceClient) Get(context.Context, client.Object, client.Object, ...client.SubResourceGetOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubSubResourceClient) Create(context.Context, client.Object, client.Object, ...client.SubResourceCreateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubSubResourceClient) Update(context.Context, client.Object, ...client.SubResourceUpdateOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *stubSubResourceClient) Patch(context.Context, client.Object, client.Patch, ...client.SubResourcePatchOption) error {
+	return fmt.Errorf("not implemented")
+}
+
+var _ client.Client = (*stubClient)(nil)
+var _ client.SubResourceClient = (*stubSubResourceClient)(nil)


### PR DESCRIPTION
## Summary
- add OpenShift-aware handling in Prometheus controller for user-workload monitoring
- add OpenShift-aware handling in Alertmanager controller for user-workload monitoring
- centralize OpenShift detection in detectors with OpenShiftManaged() for Prometheus and Alertmanager
- guard federated project-id paths to avoid non-Rancher regressions
- add detector unit tests for OpenShift detection and pre-Ready panic contract (Prometheus and Alertmanager)
- expand README with OpenShift 4.21 user workload monitoring guidance:
  - exact ConfigMap examples
  - OpenShift-native RBAC role binding examples
  - verification steps
  - optional alert-routing setup patterns

## Why
OpenShift commonly runs multiple Prometheus and Alertmanager instances (platform + user workload). This change ensures the controller behavior targets the user-workload stack appropriately and avoids unintended mutation of platform components.

## Validation
- go test ./pkg/detector
- go test ./pkg/controllers/prometheus ./pkg/detector
- go test ./pkg/controllers/alertmanager ./pkg/detector

## Docs alignment
Documentation updates were cross-checked against OpenShift user workload monitoring guidance (enableUserWorkload flow, non-admin roles, verification, and alert-routing options).
