### PR TITLE
Group alerts by additional labels in addition to 'job'

### DIFF
--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -171,7 +171,7 @@ func (r *AlertmanagerReconciler) SetupClusterForAlertmanager(ctx context.Context
 		obj.Spec.Receivers = []monitoringv1alpha1.Receiver{*receiver}
 
 		obj.Spec.Route = &monitoringv1alpha1.Route{
-			GroupBy:        []string{"job"},
+			GroupBy:        []string{"alertname", "namespace", "job", "k8s_kind", "k8s_resource"},
 			GroupWait:      "10s",
 			GroupInterval:  "1m",
 			Receiver:       receiver.Name,

--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -171,7 +171,7 @@ func (r *AlertmanagerReconciler) SetupClusterForAlertmanager(ctx context.Context
 		obj.Spec.Receivers = []monitoringv1alpha1.Receiver{*receiver}
 
 		obj.Spec.Route = &monitoringv1alpha1.Route{
-			GroupBy:        []string{"alertname", "app_namespace", "job", "k8s_kind"},
+			GroupBy:        []string{"alertname", "app", "app_namespace", "job", "k8s_kind"},
 			GroupWait:      "10s",
 			GroupInterval:  "1m",
 			Receiver:       receiver.Name,

--- a/pkg/controllers/alertmanager/alertmanager_controller.go
+++ b/pkg/controllers/alertmanager/alertmanager_controller.go
@@ -171,7 +171,7 @@ func (r *AlertmanagerReconciler) SetupClusterForAlertmanager(ctx context.Context
 		obj.Spec.Receivers = []monitoringv1alpha1.Receiver{*receiver}
 
 		obj.Spec.Route = &monitoringv1alpha1.Route{
-			GroupBy:        []string{"alertname", "namespace", "job", "k8s_kind", "k8s_resource"},
+			GroupBy:        []string{"alertname", "app_namespace", "job", "k8s_kind"},
 			GroupWait:      "10s",
 			GroupInterval:  "1m",
 			Receiver:       receiver.Name,


### PR DESCRIPTION
Avoids aggregating disconnected alerts together into the same alert group like "KubeSchedulerDown", "WatchDog", "MondoDBDown", "PostgresDown", etc.

Instead, forms alert groups consisting of alerts that have matching alertname, namespace, etc. labels.

Note: this doesn't break/ignore alerts that don't have these labels.