### PR TITLE
Add cluster name/uid as external labels to all alerts

### DIFF
--- a/pkg/controllers/prometheus/prometheus_controller.go
+++ b/pkg/controllers/prometheus/prometheus_controller.go
@@ -203,6 +203,12 @@ func (r *PrometheusReconciler) ensureExternalLabels(ctx context.Context, prom *m
 		return err
 	}
 
+	existingName, nameExists := prom.Spec.ExternalLabels[clusterLabelKey]
+	existingUID, uidExists := prom.Spec.ExternalLabels[clusterUIDLabelKey]
+	if nameExists && existingName == cm.Name && uidExists && existingUID == cm.UID {
+		return nil
+	}
+
 	original := prom.DeepCopy()
 	if prom.Spec.ExternalLabels == nil {
 		prom.Spec.ExternalLabels = make(map[string]string)

--- a/pkg/controllers/prometheus/prometheus_controller.go
+++ b/pkg/controllers/prometheus/prometheus_controller.go
@@ -62,6 +62,9 @@ const (
 	presetsMonitoring    = "monitoring-presets"
 	appBindingPrometheus = "default-prometheus"
 	appBindingGrafana    = "default-grafana"
+
+	clusterLabelKey    = "cluster"
+	clusterUIDLabelKey = "cluster_uid"
 )
 
 var (
@@ -170,6 +173,11 @@ func (r *PrometheusReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	if err := r.ensureExternalLabels(ctx, &prom); err != nil {
+		log.Error(err, "unable to ensure Prometheus external labels")
+		return ctrl.Result{}, err
+	}
+
 	vt, err := cu.CreateOrPatch(context.TODO(), r.kc, &prom, func(in client.Object, createOp bool) client.Object {
 		obj := in.(*monitoringv1.Prometheus)
 		obj.ObjectMeta = core_util.AddFinalizer(obj.ObjectMeta, mona.PrometheusKey)
@@ -187,6 +195,21 @@ func (r *PrometheusReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *PrometheusReconciler) ensureExternalLabels(ctx context.Context, prom *monitoringv1.Prometheus) error {
+	cm, err := clustermeta.ClusterMetadata(r.kc)
+	if err != nil {
+		return err
+	}
+
+	original := prom.DeepCopy()
+	if prom.Spec.ExternalLabels == nil {
+		prom.Spec.ExternalLabels = make(map[string]string)
+	}
+	prom.Spec.ExternalLabels[clusterLabelKey] = cm.Name
+	prom.Spec.ExternalLabels[clusterUIDLabelKey] = cm.UID
+	return r.kc.Patch(ctx, prom, client.MergeFrom(original))
 }
 
 func (r *PrometheusReconciler) findServiceForPrometheus(prom types.NamespacedName) (*core.Service, error) {

--- a/pkg/controllers/prometheus/prometheus_controller.go
+++ b/pkg/controllers/prometheus/prometheus_controller.go
@@ -174,7 +174,7 @@ func (r *PrometheusReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if err := r.ensureExternalLabels(ctx, &prom); err != nil {
-		log.Error(err, "unable to ensure Prometheus external labels")
+		log.Error(err, "unable to ensure Prometheus external labels. cluster info will not be injected into alerts.")
 		return ctrl.Result{}, err
 	}
 
@@ -198,9 +198,12 @@ func (r *PrometheusReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 func (r *PrometheusReconciler) ensureExternalLabels(ctx context.Context, prom *monitoringv1.Prometheus) error {
+	log := log.FromContext(ctx)
+
 	cm, err := clustermeta.ClusterMetadata(r.kc)
 	if err != nil {
-		return err
+		log.Error(err, "failed to fetch cluster metadata configmap")
+		return nil
 	}
 
 	existingName, nameExists := prom.Spec.ExternalLabels[clusterLabelKey]


### PR DESCRIPTION
This will allow us to easily differentiate between alerts from different clusters by showing cluster info in the alert body/subject/etc.

required by: https://github.com/open-viz/installer/pull/266