### PR TITLE
Fix client-org dashboard delete/recreate loop during namespace teardown

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -205,6 +205,7 @@ func (c completedConfig) New(ctx context.Context) (*UIServer, error) {
 	}, func(ctx context.Context, mgr ctrl.Manager) {
 		if err = namespacecontroller.NewReconciler(
 			mgr.GetClient(),
+			mgr.GetAPIReader(),
 			bc,
 			cid,
 			c.ExtraConfig.HubUID,

--- a/pkg/controllers/README.md
+++ b/pkg/controllers/README.md
@@ -139,24 +139,31 @@ Primary behavior:
 3. Adds finalizer `monitoring.appscode.com/prometheus`.
 4. On deletion:
    - Unregisters client-org backend context.
+   - Deletes all copied GrafanaDashboards in `<namespace>-monitoring`, then deletes the
+     monitoring namespace itself (authoritative cleanup; removing the finalizer only after
+     this succeeds avoids racing namespace GC against in-flight copy reconciles).
    - Removes finalizer.
-5. Ensures monitoring namespace `<namespace>-monitoring`.
-6. Ensures rolebinding `appscode:client-org:monitoring` in monitoring namespace.
-7. Verifies trickster registration marker exists before proceeding.
-8. Registers backend context (issue token mode), then creates/updates:
+5. Re-reads the namespace from the API server (uncached) and bails if it is terminating or
+   no longer client-org labeled, so a stale cached read can't recreate copies mid-teardown.
+6. Ensures monitoring namespace `<namespace>-monitoring`.
+7. Ensures rolebinding `appscode:client-org:monitoring` in monitoring namespace.
+8. Verifies trickster registration marker exists before proceeding.
+9. Registers backend context (issue token mode), then creates/updates:
    - AppBinding `grafana` in client monitoring namespace.
    - Secret `grafana-auth`.
-9. Copies all GrafanaDashboard objects into client monitoring namespace and transforms:
-   - dashboard title (`ClientDashboardTitle`).
-   - templating variable `namespace` as constant client namespace value.
-   - grafanaRef to local appbinding.
-   - source/hash annotations for traceability.
+10. Copies source GrafanaDashboard objects into client monitoring namespace and transforms:
+    - dashboard title (`ClientDashboardTitle`).
+    - templating variable `namespace` as constant client namespace value.
+    - grafanaRef to local appbinding.
+    - source/hash annotations for traceability.
+    - Skips objects that are already copies (carry the source annotation) or live in a
+      `-monitoring` namespace, so copies are not re-copied into an unstable loop.
 
 Watch details:
 
 - `Named("namespace")`.
 - `For(Namespace)` with client-org predicate.
-- Watches `ServiceAccount trickster` with registration label and requeues all client-org namespaces.
+- Watches `ServiceAccount trickster` with registration label and requeues all non-terminating client-org namespaces.
 
 ### ranchertoken.TokenRefresher
 

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -17,10 +17,10 @@ limitations under the License.
 package namespace
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	openvizapi "go.openviz.dev/apimachinery/apis/openviz/v1alpha1"
 	"go.openviz.dev/grafana-tools/pkg/controllers/clientorg"
@@ -60,6 +60,7 @@ import (
 // ClientOrgReconciler reconciles a GatewayConfig object
 type ClientOrgReconciler struct {
 	kc         client.Client
+	apiReader  client.Reader
 	scheme     *runtime.Scheme
 	bc         *prometheus.Client
 	clusterUID string
@@ -67,9 +68,10 @@ type ClientOrgReconciler struct {
 	d          detector.PrometheusDetector
 }
 
-func NewReconciler(kc client.Client, bc *prometheus.Client, clusterUID, hubUID string, d detector.PrometheusDetector) *ClientOrgReconciler {
+func NewReconciler(kc client.Client, apiReader client.Reader, bc *prometheus.Client, clusterUID, hubUID string, d detector.PrometheusDetector) *ClientOrgReconciler {
 	return &ClientOrgReconciler{
 		kc:         kc,
+		apiReader:  apiReader,
 		scheme:     kc.Scheme(),
 		bc:         bc,
 		clusterUID: clusterUID,
@@ -124,6 +126,16 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
+		// Authoritatively clean up everything this controller created in the client monitoring namespace before dropping the finalizer.
+		monNs := clientorg.MonitoringNamespace(ns.Name)
+		if err := r.kc.DeleteAllOf(ctx, &openvizapi.GrafanaDashboard{}, client.InNamespace(monNs)); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		monNamespace := core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: monNs}}
+		if err := r.kc.Delete(ctx, &monNamespace); client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, err
+		}
+
 		vt, err := cu.CreateOrPatch(context.TODO(), r.kc, &ns, func(in client.Object, createOp bool) client.Object {
 			obj := in.(*core.Namespace)
 			obj.ObjectMeta = core_util.RemoveFinalizer(obj.ObjectMeta, mona.PrometheusKey)
@@ -134,6 +146,21 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 		klog.Infof("%s Namespace %s to remove finalizer %s", vt, ns.Name, mona.PrometheusKey)
+		return ctrl.Result{}, nil
+	}
+
+	// The cached client lags the API server, and the ServiceAccount watch re-enqueues every
+	// client-org namespace on each trickster token refresh. A reconcile fired during teardown
+	// can therefore still observe a stale, live-looking namespace and recreate the copied
+	// dashboards that cleanup just removed. Re-read from the API server before (re)creating
+	// anything and bail out if the namespace is no longer an active client org.
+	var fresh core.Namespace
+	if err := r.apiReader.Get(ctx, req.NamespacedName, &fresh); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if fresh.DeletionTimestamp != nil ||
+		fresh.Labels[kmapi.ClientOrgKey] == "" ||
+		fresh.Labels[kmapi.ClientOrgKey] == "terminating" {
 		return ctrl.Result{}, nil
 	}
 
@@ -301,6 +328,9 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var errList []error
 	for _, dashboard := range dashboardList.Items {
+		if _, isCopy := dashboard.Annotations[srcRefKey]; isCopy || strings.HasSuffix(dashboard.Namespace, "-monitoring") {
+			continue
+		}
 		if dashboard.Spec.Model == nil {
 			return ctrl.Result{}, apierrors.NewBadRequest(fmt.Sprintf("GrafanaDashboard %s/%s is missing a model", dashboard.Namespace, dashboard.Name))
 		}
@@ -322,10 +352,6 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		boardBytes, err := json.Marshal(board)
 		if err != nil {
 			return ctrl.Result{}, err
-		}
-
-		if _, found := dashboard.Annotations[srcRefKey]; found && bytes.Equal(dashboard.Spec.Model.Raw, boardBytes) {
-			continue
 		}
 
 		copiedDashboard := &openvizapi.GrafanaDashboard{}
@@ -493,6 +519,9 @@ func (r *ClientOrgReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 			reqs := make([]reconcile.Request, 0, len(list.Items))
 			for _, ns := range list.Items {
+				if ns.DeletionTimestamp != nil {
+					continue
+				}
 				reqs = append(reqs, reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name: ns.Name,


### PR DESCRIPTION
## Problem

A copied `GrafanaDashboard` in a `{client}-monitoring` namespace was continuously deleted and recreated, even while the client-org namespace was terminating.

Root cause is a combination of defects in `namespace.ClientOrgReconciler`:

1. **No authoritative cleanup.** Nothing in the repo deletes the copied dashboard CR — removal happened only incidentally via namespace GC. The deletion branch only unregistered the backend and dropped its finalizer.
2. **Recreation race.** Copying was gated on a *cached* namespace read. The informer cache lags the API server, and the trickster `ServiceAccount` watch re-enqueues every client-org namespace on each token refresh. A reconcile fired during teardown could still see the namespace as live and re-run the copy loop, recreating dashboards GC had just removed — which the openviz controller then re-pushed to Grafana.
3. **Never-settling object.** The cluster-wide, unfiltered dashboard `List` re-enumerated already-copied dashboards (carrying `srcRefKey`) and re-copied them, so on any name collision the target copy flipped its `srcRef`/`hash`/model every pass and was never `VerbUnchanged`.

## Changes

- **Authoritative cleanup on delete:** delete all copied dashboards in `{client}-monitoring` and then the monitoring namespace itself, *before* removing the finalizer. A failed cleanup requeues while the copy loop stays gated by `DeletionTimestamp`.
- **Uncached re-read guard** before the copy loop; bail if the namespace is terminating or no longer client-org labeled. Closes the stale-cache window.
- **List filter:** skip dashboards that are already copies (`srcRefKey`) or live in a `-monitoring` namespace.
- **Watch tightening:** skip terminating namespaces in the trickster SA mapfunc.
- Plumbed `mgr.GetAPIReader()` into the reconciler; updated `pkg/controllers/README.md`.

## Testing

`go build ./...` passes.
