### PR TITLE
Fix e2e GrafanaDashboard CreateOrPatch to preserve server metadata

### DIFF
--- a/test/e2e/framework/dashboard.go
+++ b/test/e2e/framework/dashboard.go
@@ -43,7 +43,9 @@ func (f *Framework) GetGrafanaDashboard() (*api.GrafanaDashboard, error) {
 
 func (f *Framework) CreateOrUpdateGrafanaDashboard(db *api.GrafanaDashboard) error {
 	_, err := kmc.CreateOrPatch(context.TODO(), f.cc, db, func(obj client.Object, createOp bool) client.Object {
-		return db
+		in := obj.(*api.GrafanaDashboard)
+		in.Spec = db.Spec
+		return in
 	})
 	return err
 }


### PR DESCRIPTION
## Problem

All e2e dashboard specs fail with:

```
patch: Invalid value: "{...managedFields...}": Object 'Kind' is missing
```

## Root cause

`test/e2e/framework/dashboard.go`'s `CreateOrUpdateGrafanaDashboard` returned the externally captured `db` from the `kmc.CreateOrPatch` transform instead of mutating the fetched `obj`. `CreateOrPatch`'s `assign()` copies the created server object (with `managedFields`/`resourceVersion`) back into `db` after the first call, so subsequent patches diffed against stale metadata and produced a malformed patch body that the k8s 1.34 apiserver (bumped in e3e1f810) now rejects.

## Fix

Mutate the passed `obj` and set only `Spec` from `db`, matching the idiomatic pattern already used in `namespace_controller.go` and `grafanadatasource_controller.go`.