### PR TITLE
Fix e2e suite: PersesDashboard CRD bootstrap, finalizer resurrection, panic guard, diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,44 @@ jobs:
           echo
           make e2e-tests
 
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          for dep in grafana-operator monitoring-operator; do
+            echo "::group::$dep operator logs (current)"
+            kubectl logs -n monitoring deployment/$dep --tail=-1 || true
+            echo "::endgroup::"
+
+            echo "::group::$dep operator logs (previous)"
+            kubectl logs -n monitoring deployment/$dep --previous --tail=-1 || true
+            echo "::endgroup::"
+          done
+
+          echo "::group::operator deployments + pods (monitoring)"
+          kubectl describe deployment -n monitoring grafana-operator monitoring-operator || true
+          kubectl get pods -n monitoring -o wide || true
+          echo "::endgroup::"
+
+          echo "::group::e2e grafana server (test namespaces)"
+          for ns in $(kubectl get ns -o name | grep '/grafana-' | cut -d/ -f2); do
+            echo "--- namespace $ns ---"
+            kubectl get pods -n "$ns" -o wide || true
+            kubectl logs -n "$ns" -l app --tail=-1 --prefix || true
+          done
+          echo "::endgroup::"
+
+          echo "::group::GrafanaDashboards (all namespaces)"
+          kubectl get grafanadashboards.openviz.dev -A -o yaml || true
+          echo "::endgroup::"
+
+          echo "::group::AppBindings (all namespaces)"
+          kubectl get appbindings.appcatalog.appscode.com -A -o yaml || true
+          echo "::endgroup::"
+
+          echo "::group::cluster events"
+          kubectl get events -A --sort-by=.lastTimestamp | tail -n 100 || true
+          echo "::endgroup::"
+
   cleanup:
     name: Cleanup
     runs-on: ubuntu-24.04

--- a/pkg/controllers/config.go
+++ b/pkg/controllers/config.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	openvizapi "go.openviz.dev/apimachinery/apis/openviz/v1alpha1"
+	openvizcrds "go.openviz.dev/apimachinery/crds"
 
 	crd_cs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/klog/v2"
@@ -30,6 +31,7 @@ func EnsureCustomResourceDefinitions(client crd_cs.Interface) error {
 	crds := []*apiextensions.CustomResourceDefinition{
 		openvizapi.GrafanaDashboard{}.CustomResourceDefinition(),
 		openvizapi.GrafanaDatasource{}.CustomResourceDefinition(),
+		openvizcrds.MustCustomResourceDefinition(openvizapi.SchemeGroupVersion.WithResource(openvizapi.ResourcePersesDashboards)),
 		appcatalogapi.AppBinding{}.CustomResourceDefinition(),
 	}
 	return apiextensions.RegisterCRDs(client, crds)

--- a/pkg/controllers/openviz/grafanadashboard_controller.go
+++ b/pkg/controllers/openviz/grafanadashboard_controller.go
@@ -101,12 +101,13 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 
-		// Remove finalizer as the external Dashboard is successfully deleted
-		_, err := kmc.CreateOrPatch(ctx, r.Client, obj, func(obj client.Object, createOp bool) client.Object {
-			controllerutil.RemoveFinalizer(obj, GrafanaDashboardFinalizer)
-			return obj
-		})
-		return ctrl.Result{}, err
+		// Remove finalizer as the external Dashboard is successfully deleted.
+		// Use a plain patch (not CreateOrPatch): once the last finalizer is
+		// gone the object is removed, and a re-queued delete reconcile would
+		// otherwise Get->NotFound->Create and resurrect the GrafanaDashboard.
+		base := client.MergeFrom(obj.DeepCopy())
+		controllerutil.RemoveFinalizer(obj, GrafanaDashboardFinalizer)
+		return ctrl.Result{}, client.IgnoreNotFound(r.Patch(ctx, obj, base))
 	}
 
 	// Add finalizer if not set
@@ -291,7 +292,7 @@ func (r *GrafanaDashboardReconciler) setDashboard(ctx context.Context, obj *open
 		return r.handleSetDashboardError(ctx, obj, err, false)
 	}
 
-	if obj.Status.Dashboard != nil && (obj.Status.Dashboard.State == nil || *obj.Status.Dashboard.State == state) {
+	if obj.Spec.Model != nil && obj.Status.Dashboard != nil && (obj.Status.Dashboard.State == nil || *obj.Status.Dashboard.State == state) {
 		model, err := addDashboardID(obj.Spec.Model.Raw, *obj.Status.Dashboard.ID, *obj.Status.Dashboard.UID)
 		if err != nil {
 			return r.handleSetDashboardError(ctx, obj, err, false)

--- a/pkg/controllers/openviz/persesdashboard_controller.go
+++ b/pkg/controllers/openviz/persesdashboard_controller.go
@@ -97,12 +97,13 @@ func (r *PersesDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
-		// Remove finalizer as the external Dashboard is successfully deleted
-		_, err := kmc.CreateOrPatch(ctx, r.Client, obj, func(obj client.Object, createOp bool) client.Object {
-			controllerutil.RemoveFinalizer(obj, PersesDashboardFinalizer)
-			return obj
-		})
-		return ctrl.Result{}, err
+		// Remove finalizer as the external Dashboard is successfully deleted.
+		// Use a plain patch (not CreateOrPatch): once the last finalizer is
+		// gone the object is removed, and a re-queued delete reconcile would
+		// otherwise Get->NotFound->Create and resurrect the PersesDashboard.
+		base := client.MergeFrom(obj.DeepCopy())
+		controllerutil.RemoveFinalizer(obj, PersesDashboardFinalizer)
+		return ctrl.Result{}, client.IgnoreNotFound(r.Patch(ctx, obj, base))
 	}
 
 	// Add finalizer if not set
@@ -249,6 +250,10 @@ func (r *PersesDashboardReconciler) setDashboard(ctx context.Context, obj *openv
 	pc, err := perses.NewPersesClient(ctx, r.Client, obj.Spec.PersesRef.WithNamespace(obj.Namespace))
 	if err != nil {
 		return r.handleSetDashboardError(ctx, obj, err, false)
+	}
+
+	if obj.Spec.Model == nil {
+		return r.handleSetDashboardError(ctx, obj, fmt.Errorf("dashboard model is empty"), false)
 	}
 
 	var pDB v1.Dashboard

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/url"
+	"time"
 
 	openvizapi "go.openviz.dev/apimachinery/apis/openviz/v1alpha1"
 	sdk "go.openviz.dev/grafana-sdk"
@@ -31,6 +32,8 @@ import (
 	appcatalog "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const grafanaClientTimeout = 30 * time.Second
 
 func NewGrafanaClient(ctx context.Context, kc client.Client, ref *kmapi.ObjectReference) (*sdk.Client, error) {
 	ab, err := openvizapi.GetGrafana(ctx, kc, ref)
@@ -56,6 +59,8 @@ func newGrafanaClient(ctx context.Context, kc client.Client, ab *appcatalog.AppB
 		return nil, err
 	}
 	httpClient := resty.New()
+	// Never let a single Grafana HTTP call block a reconcile indefinitely.
+	httpClient.SetTimeout(grafanaClientTimeout)
 	if cfg.TLS != nil && len(cfg.TLS.CABundle) > 0 {
 		httpClient.SetRootCertificateFromString(string(cfg.TLS.CABundle))
 	}


### PR DESCRIPTION
## Summary

The Kubernetes e2e suite had been red for months. This PR makes it green again (**7/7 specs pass, ~9s** vs. ~11m of timeouts) by fixing the operator bugs that broke it, plus the CI diagnostics that hid them.

Two commits:

### `Fix GrafanaDashboard/PersesDashboard reconcilers so the e2e suite passes`
Three operator bugs, peeled back one at a time:

- **Missing `PersesDashboard` CRD.** The Perses controller (#198) was registered but its CRD was never bootstrapped. `grafana-operator` crash-looped on `failed to wait for persesdashboard caches to sync` (7 restarts), and `monitoring-operator` died with `no matches for kind "PersesDashboard"` (CrashLoopBackOff). Added it to `EnsureCustomResourceDefinitions`.

- **Finalizer resurrection on delete** — the real reason deletions hung for 300s. The delete handler removed the finalizer with `kmc.CreateOrPatch`, so a re-queued delete reconcile ran `Get → NotFound → Create` and recreated the just-deleted dashboard, which re-added its finalizer and re-pushed to Grafana — an endless delete→recreate loop. Now removes the finalizer with a plain `MergeFrom` patch + `IgnoreNotFound`. Same fix in the Perses reconciler.

- **Nil-pointer panic.** `setDashboard` dereferenced `obj.Spec.Model.Raw` without a nil check, panic-looping when `Status.Dashboard` was set but `Spec.Model` was nil.

Also set a 30s timeout on the Grafana HTTP client so a single API call can never block a reconcile indefinitely.

### `Capture operator logs and resource state on e2e failure`
CI only dumped operator logs when `make install` failed, not when specs failed, and pointed at `openviz/grafana-tools` even though `make install` deploys into `monitoring` as `grafana-operator` and `monitoring-operator` — so the logs came back empty and the real errors stayed hidden. Adds an `if: failure()` step that dumps both operators' current+previous logs, their deployment/pod state, the e2e Grafana server pods in the random `grafana-<suffix>` test namespaces, GrafanaDashboards, AppBindings, and recent cluster events.

## Testing
Kubernetes e2e job: `SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 0 Skipped`.