### PR TITLE
Guard nil AuthConfig/TLS in newPersesClient

### DIFF
--- a/pkg/perses/client.go
+++ b/pkg/perses/client.go
@@ -98,8 +98,12 @@ func newPersesClient(ctx context.Context, kc client.Client, ab *appcatalog.AppBi
 	}
 	c := &Client{
 		baseURL: cfg.Addr,
-		token:   cfg.AuthConfig.BearerToken,
-		caCert:  cfg.TLS.CABundle,
+	}
+	if cfg.AuthConfig != nil {
+		c.token = cfg.AuthConfig.BearerToken
+	}
+	if cfg.TLS != nil {
+		c.caCert = cfg.TLS.CABundle
 	}
 	if len(c.caCert) == 0 {
 		u, err := url.Parse(c.baseURL)


### PR DESCRIPTION
## Problem

`newPersesClient` (pkg/perses/client.go) dereferenced `cfg.AuthConfig` and `cfg.TLS` unconditionally:

```go
token:  cfg.AuthConfig.BearerToken,
caCert: cfg.TLS.CABundle,
```

But `GetGrafanaConfig` leaves:
- `cfg.AuthConfig` nil when the AppBinding has no Secret,
- `cfg.TLS` nil when the AppBinding has no `CABundle`.

A perses AppBinding without a CA bundle (plain HTTP / no custom CA) therefore panicked the whole operator process at `cfg.TLS.CABundle`, crash-looping the pod. Observed stack:

```
pkg/perses/client.go:102  newPersesClient
persesdashboard_controller.go:250  setDashboard
persesdashboard_controller.go:134  Reconcile
```

## Fix

Nil-check both `cfg.AuthConfig` and `cfg.TLS` before dereferencing. A CABundle-less / secret-less AppBinding now yields a client with no bearer token / no custom CA instead of panicking.

`go build ./pkg/perses/... ./pkg/controllers/...` passes.

## Note

This fixes the fatal crash only. Two related issues are tracked separately (not in this PR): the per-client-org `perses` AppBinding is not recreated after deletion due to shared `RegisteredKey` gating, and the AppBinding watch handler returns nil for all dashboards when any one errors.