### PR TITLE
Stamp default marker after perses; self-heal perses dashboard watch

### DIFF
--- a/pkg/controllers/openviz/persesdashboard_controller.go
+++ b/pkg/controllers/openviz/persesdashboard_controller.go
@@ -168,7 +168,9 @@ func (r *PersesDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		for _, db := range dashboardList.Items {
 			ab, err := perses.GetPerses(ctx, r.Client, db.Spec.PersesRef.WithNamespace(db.Namespace))
 			if err != nil {
-				return nil
+				// Skip only this dashboard; one unresolvable AppBinding must not suppress
+				// requeue of every other dashboard watching this AppBinding.
+				continue
 			}
 
 			if ab.Name == a.GetName() &&

--- a/pkg/controllers/prometheus/prometheus_controller.go
+++ b/pkg/controllers/prometheus/prometheus_controller.go
@@ -469,12 +469,6 @@ func (r *PrometheusReconciler) SetupClusterForPrometheus(ctx context.Context, pr
 			}
 		}
 
-		rbvt, err = cu.CreateOrPatch(context.TODO(), r.kc, &rb, applyMarkers)
-		if err != nil {
-			return err
-		}
-		klog.Infof("%s rolebinding %s/%s with %s annotation", rbvt, rb.Namespace, rb.Name, RegisteredKey)
-
 		persesResp, err := r.bc.RegisterPerses(mona.PrometheusContext{
 			HubUID:     r.hubUID,
 			ClusterUID: r.clusterUID,
@@ -496,6 +490,15 @@ func (r *PrometheusReconciler) SetupClusterForPrometheus(ctx context.Context, pr
 				return err
 			}
 		}
+
+		// Mark the RoleBinding registered only after BOTH grafana and perses registration
+		// succeed. If set before RegisterPerses, a perses failure would leave the marker set,
+		// skipping this whole block on the next reconcile so default-perses is never created.
+		rbvt, err = cu.CreateOrPatch(context.TODO(), r.kc, &rb, applyMarkers)
+		if err != nil {
+			return err
+		}
+		klog.Infof("%s rolebinding %s/%s with %s annotation", rbvt, rb.Namespace, rb.Name, RegisteredKey)
 
 	}
 


### PR DESCRIPTION
Two fixes:

- `prometheus_controller.go`: stamp the default registration marker only after perses registration succeeds, so a perses failure no longer permanently skips default-perses creation.
- `persesdashboard_controller.go`: `continue` instead of `return nil` in the AppBinding watch handler, so one unresolvable AppBinding no longer suppresses requeue of the others.

Client-org namespace change split out to #208.