### PR TITLE
Clean up client-org backends when namespace label flips to terminating

### DIFF
--- a/pkg/controllers/namespace/backend.go
+++ b/pkg/controllers/namespace/backend.go
@@ -41,13 +41,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// appBindingExists reports whether the named AppBinding is present in the given namespace.
 func (r *ClientOrgReconciler) appBindingExists(ctx context.Context, namespace, name string) bool {
 	var ab appcatalog.AppBinding
 	return r.kc.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ab) == nil
 }
 
-// setNamespaceMarker stamps the shared registration marker on the namespace.
 func (r *ClientOrgReconciler) setNamespaceMarker(ctx context.Context, monNamespace *core.Namespace, state string) error {
 	rbvt, err := cu.CreateOrPatch(ctx, r.kc, monNamespace, func(in client.Object, _ bool) client.Object {
 		obj := in.(*core.Namespace)
@@ -66,9 +64,6 @@ func (r *ClientOrgReconciler) setNamespaceMarker(ctx context.Context, monNamespa
 	return nil
 }
 
-// buildPrometheusConfig confirms the trickster RoleBinding backing promKey's Prometheus has
-// been registered, then builds the mona.PrometheusConfig used to register the grafana/perses
-// backends for the client-org.
 func (r *ClientOrgReconciler) buildPrometheusConfig(ctx context.Context, promKey client.ObjectKey, svcProm core.Service) (mona.PrometheusConfig, error) {
 	var rbProm rbac.RoleBinding
 	if err := r.kc.Get(ctx, client.ObjectKey{Name: prometheus.CRTrickster, Namespace: svcProm.Namespace}, &rbProm); err != nil {
@@ -111,11 +106,9 @@ func (r *ClientOrgReconciler) buildPrometheusConfig(ctx context.Context, promKey
 	return pcfg, nil
 }
 
-// registerBackends runs the grafana/perses self-healing backend registration: each backend
-// re-registers when the shared marker is stale (cluster state changed) or its AppBinding is
-// missing (external deletion, or an org first registered before perses support). Errors are
-// aggregated so a hub failure on one backend does not block the other. The marker is stamped
-// only once both backends succeed.
+// registerBackends re-registers each backend when the shared marker is stale (cluster state
+// changed) or its AppBinding is missing. Errors are aggregated so a hub failure on one backend
+// does not block the other.
 func (r *ClientOrgReconciler) registerBackends(ctx context.Context, monNamespace *core.Namespace, pcfg mona.PrometheusConfig, clientOrgId, state string) error {
 	var errs []error
 
@@ -137,9 +130,8 @@ func (r *ClientOrgReconciler) registerBackends(ctx context.Context, monNamespace
 		}
 	}
 
-	// Stamp the marker only after BOTH backends succeed. Stamping on a perses failure would
-	// leave the marker set, skipping this whole block on the next reconcile so a failed
-	// perses AppBinding is never recreated.
+	// Stamp the marker only after BOTH backends succeed, otherwise a failed backend's block is
+	// skipped on the next reconcile and its AppBinding is never recreated.
 	if grafanaOK && persesOK {
 		if err := r.setNamespaceMarker(ctx, monNamespace, state); err != nil {
 			errs = append(errs, err)
@@ -149,8 +141,6 @@ func (r *ClientOrgReconciler) registerBackends(ctx context.Context, monNamespace
 	return utilerrors.NewAggregate(errs)
 }
 
-// registerGrafanaBackend registers the client-org against the Grafana backend and creates its
-// AppBinding. It does not stamp the marker; the caller stamps once both backends succeed.
 func (r *ClientOrgReconciler) registerGrafanaBackend(monNamespace string, pcfg mona.PrometheusConfig, clientOrgId string) error {
 	resp, err := r.pc.Register(mona.PrometheusContext{
 		HubUID:      r.hubUID,
@@ -167,8 +157,6 @@ func (r *ClientOrgReconciler) registerGrafanaBackend(monNamespace string, pcfg m
 	return r.CreateGrafanaAppBinding(monNamespace, resp)
 }
 
-// registerPersesBackend registers the client-org against the Perses backend and creates its
-// AppBinding. It does not stamp the marker; the caller stamps once both backends succeed.
 func (r *ClientOrgReconciler) registerPersesBackend(monNamespace string, pcfg mona.PrometheusConfig, clientOrgId string) error {
 	persesResp, err := r.pc.RegisterPerses(mona.PrometheusContext{
 		HubUID:      r.hubUID,
@@ -196,33 +184,10 @@ func (r *ClientOrgReconciler) CreateGrafanaAppBinding(monNamespace string, resp 
 	abvt, err := cu.CreateOrPatch(context.TODO(), r.kc, &ab, func(in client.Object, createOp bool) client.Object {
 		obj := in.(*appcatalog.AppBinding)
 
-		//ref := metav1.NewControllerRef(prom, schema.GroupVersionKind{
-		//	Group:   monitoring.GroupName,
-		//	Version: monitoringv1.Version,
-		//	Kind:    "Prometheus",
-		//})
-		//obj.OwnerReferences = []metav1.OwnerReference{*ref}
-		//
-		//if obj.Annotations == nil {
-		//	obj.Annotations = make(map[string]string)
-		//}
-		//obj.Annotations["monitoring.appscode.com/is-default-grafana"] = "true"
-
 		obj.Spec.Type = "Grafana"
 		obj.Spec.AppRef = nil
 		obj.Spec.ClientConfig = appcatalog.ClientConfig{
 			URL: ptr.To(resp.Grafana.URL),
-			//Service: &appcatalog.ServiceReference{
-			//	Scheme:    "http",
-			//	Namespace: svc.Namespace,
-			//	Name:      svc.Name,
-			//	Port:      0,
-			//	Path:      "",
-			//	Query:     "",
-			//},
-			//InsecureSkipTLSVerify: false,
-			//CABundle:              nil,
-			//ServerName:            "",
 		}
 		obj.Spec.Secret = &appcatalog.TypedLocalObjectReference{
 			APIGroup: "",
@@ -298,33 +263,10 @@ func (r *ClientOrgReconciler) CreatePersesAppBinding(monNamespace string, resp *
 	abvt, err := cu.CreateOrPatch(context.TODO(), r.kc, &ab, func(in client.Object, createOp bool) client.Object {
 		obj := in.(*appcatalog.AppBinding)
 
-		//ref := metav1.NewControllerRef(prom, schema.GroupVersionKind{
-		//	Group:   monitoring.GroupName,
-		//	Version: monitoringv1.Version,
-		//	Kind:    "Prometheus",
-		//})
-		//obj.OwnerReferences = []metav1.OwnerReference{*ref}
-		//
-		//if obj.Annotations == nil {
-		//	obj.Annotations = make(map[string]string)
-		//}
-		//obj.Annotations["monitoring.appscode.com/is-default-grafana"] = "true"
-
 		obj.Spec.Type = "Perses"
 		obj.Spec.AppRef = nil
 		obj.Spec.ClientConfig = appcatalog.ClientConfig{
 			URL: ptr.To(resp.Perses.URL),
-			//Service: &appcatalog.ServiceReference{
-			//	Scheme:    "http",
-			//	Namespace: svc.Namespace,
-			//	Name:      svc.Name,
-			//	Port:      0,
-			//	Path:      "",
-			//	Query:     "",
-			//},
-			//InsecureSkipTLSVerify: false,
-			//CABundle:              nil,
-			//ServerName:            "",
 		}
 		obj.Spec.Secret = &appcatalog.TypedLocalObjectReference{
 			Name:     ab.Name + "-auth",

--- a/pkg/controllers/namespace/dashboard.go
+++ b/pkg/controllers/namespace/dashboard.go
@@ -41,8 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// copyDashboards copies both grafana and perses dashboards into the client monitoring
-// namespace, aggregating the per-dashboard (soft) errors from each into a single error.
 func (r *ClientOrgReconciler) copyDashboards(ctx context.Context, ns, monNamespace core.Namespace) error {
 	var errList []error
 
@@ -62,9 +60,8 @@ func (r *ClientOrgReconciler) copyDashboards(ctx context.Context, ns, monNamespa
 }
 
 // copyGrafanaDashboards copies every source GrafanaDashboard into the client monitoring
-// namespace, pinning the "namespace" templating variable to the client-org namespace and
-// re-titling for the client. The returned slice holds per-dashboard (soft) errors; a
-// non-nil error aborts the whole reconcile as before.
+// namespace, pinning the "namespace" templating variable to the client-org namespace. The
+// returned slice holds per-dashboard soft errors; a returned error aborts the reconcile.
 func (r *ClientOrgReconciler) copyGrafanaDashboards(ctx context.Context, ns, monNamespace core.Namespace) ([]error, error) {
 	log := log.FromContext(ctx)
 
@@ -127,7 +124,6 @@ func (r *ClientOrgReconciler) copyGrafanaDashboards(ctx context.Context, ns, mon
 			copiedDashboard.Annotations[srcRefKey] = client.ObjectKeyFromObject(&dashboard).String()
 			copiedDashboard.Annotations[srcHashKey] = meta.ObjectHash(&dashboard)
 
-			// use client Grafana appbinding
 			copiedDashboard.Spec.GrafanaRef = &kmapi.ObjectReference{
 				Namespace: monNamespace.Name,
 				Name:      abClientOrgGrafana,
@@ -149,8 +145,8 @@ func (r *ClientOrgReconciler) copyGrafanaDashboards(ctx context.Context, ns, mon
 }
 
 // copyPersesDashboards copies every source PersesDashboard into the client monitoring
-// namespace, re-titling for the client. The returned slice holds per-dashboard (soft)
-// errors; a non-nil error aborts the whole reconcile as before.
+// namespace. The returned slice holds per-dashboard soft errors; a returned error aborts
+// the reconcile.
 func (r *ClientOrgReconciler) copyPersesDashboards(ctx context.Context, monNamespace core.Namespace) ([]error, error) {
 	log := log.FromContext(ctx)
 
@@ -206,7 +202,6 @@ func (r *ClientOrgReconciler) copyPersesDashboards(ctx context.Context, monNames
 			copiedDashboard.Annotations[srcRefKey] = client.ObjectKeyFromObject(&dashboard).String()
 			copiedDashboard.Annotations[srcHashKey] = meta.ObjectHash(&dashboard)
 
-			// use client Grafana appbinding
 			copiedDashboard.Spec.PersesRef = &kmapi.ObjectReference{
 				Namespace: monNamespace.Name,
 				Name:      abClientOrgPerses,

--- a/pkg/controllers/namespace/helpers.go
+++ b/pkg/controllers/namespace/helpers.go
@@ -51,6 +51,7 @@ func isActiveClientOrg(ns *core.Namespace) bool {
 func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namespace, clientOrgId string) (ctrl.Result, error) {
 	if r.pc != nil {
 		err := r.pc.Unregister(mona.PrometheusContext{
+			HubUID:      r.hubUID,
 			ClusterUID:  r.clusterUID,
 			ProjectId:   "",
 			Default:     false,
@@ -62,6 +63,7 @@ func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namesp
 		}
 
 		err = r.pc.UnregisterPerses(mona.PrometheusContext{
+			HubUID:      r.hubUID,
 			ClusterUID:  r.clusterUID,
 			ProjectId:   "",
 			Default:     false,

--- a/pkg/controllers/namespace/helpers.go
+++ b/pkg/controllers/namespace/helpers.go
@@ -38,47 +38,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// isActiveClientOrg reports whether the namespace is still a live, non-terminating client-org.
 func isActiveClientOrg(ns *core.Namespace) bool {
 	return ns.DeletionTimestamp == nil &&
 		ns.Labels[kmapi.ClientOrgKey] != "" &&
 		ns.Labels[kmapi.ClientOrgKey] != "terminating"
 }
 
-// handleDeletion unregisters the client-org from the grafana/perses backends, deletes
-// everything this controller created in the client monitoring namespace, and drops the
-// finalizer so the namespace can finish terminating.
 func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namespace, clientOrgId string) (ctrl.Result, error) {
+	// Unregister is best-effort: a hub failure here must not block teardown, otherwise the
+	// namespace stays stuck in terminating forever whenever the backend is unreachable. Log
+	// and continue so the local cleanup and finalizer removal below always run.
 	if r.pc != nil {
-		err := r.pc.Unregister(mona.PrometheusContext{
+		if err := r.pc.Unregister(mona.PrometheusContext{
 			HubUID:      r.hubUID,
 			ClusterUID:  r.clusterUID,
 			ProjectId:   "",
 			Default:     false,
 			IssueToken:  true,
 			ClientOrgID: clientOrgId,
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to unregister grafana backend for client-org %s: %w", clientOrgId, err)
+		}); err != nil {
+			klog.Errorf("failed to unregister grafana backend for client-org %s: %v", clientOrgId, err)
 		}
 
-		err = r.pc.UnregisterPerses(mona.PrometheusContext{
+		if err := r.pc.UnregisterPerses(mona.PrometheusContext{
 			HubUID:      r.hubUID,
 			ClusterUID:  r.clusterUID,
 			ProjectId:   "",
 			Default:     false,
 			IssueToken:  true,
 			ClientOrgID: clientOrgId,
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to unregister perses backend for client-org %s: %w", clientOrgId, err)
+		}); err != nil {
+			klog.Errorf("failed to unregister perses backend for client-org %s: %v", clientOrgId, err)
 		}
-		klog.Infof("unregistered grafana/perses backends for client-org %s", clientOrgId)
+		klog.Infof("unregister attempt for grafana/perses backends done for client-org %s", clientOrgId)
 	}
 
-	// Clean up the dashboards this controller copied into the client monitoring namespace
-	// before dropping the finalizer. The monitoring namespace itself is left to its owner
-	// (the operator ServiceAccount is not granted namespace deletion).
+	// The monitoring namespace itself is left to its owner; the operator ServiceAccount is not
+	// granted namespace deletion.
 	monNs := clientorg.MonitoringNamespace(ns.Name)
 	if err := r.kc.DeleteAllOf(ctx, &openvizapi.GrafanaDashboard{}, client.InNamespace(monNs)); err != nil && !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err
@@ -102,8 +98,6 @@ func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namesp
 	return ctrl.Result{}, nil
 }
 
-// markCleanedUp stamps the cleaned-up marker on a "terminating" client-org namespace so a
-// later reconcile of the still-present namespace skips the (already done) teardown.
 func (r *ClientOrgReconciler) markCleanedUp(ctx context.Context, ns *core.Namespace) error {
 	_, err := cu.Patch(ctx, r.kc, ns, func(in client.Object) client.Object {
 		obj := in.(*core.Namespace)
@@ -117,7 +111,6 @@ func (r *ClientOrgReconciler) markCleanedUp(ctx context.Context, ns *core.Namesp
 	return err
 }
 
-// ensureFinalizer adds the shared Prometheus finalizer to the namespace.
 func (r *ClientOrgReconciler) ensureFinalizer(ctx context.Context, ns *core.Namespace) error {
 	vt, err := cu.CreateOrPatch(ctx, r.kc, ns, func(in client.Object, createOp bool) client.Object {
 		obj := in.(*core.Namespace)
@@ -134,9 +127,6 @@ func (r *ClientOrgReconciler) ensureFinalizer(ctx context.Context, ns *core.Name
 	return nil
 }
 
-// ensureMonitoringNamespace gets or creates the client's "{client}-monitoring" namespace.
-// If that namespace is mid-teardown, it returns a non-zero RequeueAfter so the caller
-// waits for it to fully delete before recreating it.
 func (r *ClientOrgReconciler) ensureMonitoringNamespace(ctx context.Context, ns core.Namespace) (core.Namespace, ctrl.Result, error) {
 	monNamespace := core.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -151,19 +141,14 @@ func (r *ClientOrgReconciler) ensureMonitoringNamespace(ctx context.Context, ns 
 	case err != nil:
 		return monNamespace, ctrl.Result{}, err
 	case monNamespace.DeletionTimestamp != nil:
-		// The monitoring namespace is being torn down (teardown deleted it, while a
-		// stale-cache reconcile of the still-present client-org namespace re-entered
-		// this live branch). Registering backends or copying dashboards into a
-		// terminating namespace is rejected by admission and just flaps create/delete.
-		// Wait for it to fully delete, then recreate it cleanly on a later reconcile.
+		// Registering backends or copying dashboards into a terminating namespace is rejected
+		// by admission and just flaps create/delete; wait for it to fully delete first.
 		klog.Infof("monitoring namespace %s is terminating, requeueing", monNamespace.Name)
 		return monNamespace, ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	return monNamespace, ctrl.Result{}, nil
 }
 
-// ensureMonitoringRoleBinding creates/patches the RoleBinding granting the client-org's
-// group access to its monitoring namespace, used to generate grafana links.
 func (r *ClientOrgReconciler) ensureMonitoringRoleBinding(ctx context.Context, monNamespace core.Namespace, clientOrgId string) error {
 	rb := rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/namespace/helpers.go
+++ b/pkg/controllers/namespace/helpers.go
@@ -76,16 +76,14 @@ func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namesp
 		klog.Infof("unregistered grafana/perses backends for client-org %s", clientOrgId)
 	}
 
-	// Authoritatively clean up everything this controller created in the client monitoring namespace before dropping the finalizer.
+	// Clean up the dashboards this controller copied into the client monitoring namespace
+	// before dropping the finalizer. The monitoring namespace itself is left to its owner
+	// (the operator ServiceAccount is not granted namespace deletion).
 	monNs := clientorg.MonitoringNamespace(ns.Name)
 	if err := r.kc.DeleteAllOf(ctx, &openvizapi.GrafanaDashboard{}, client.InNamespace(monNs)); err != nil && !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
 	if err := r.kc.DeleteAllOf(ctx, &openvizapi.PersesDashboard{}, client.InNamespace(monNs)); err != nil && !apierrors.IsNotFound(err) {
-		return ctrl.Result{}, err
-	}
-	monNamespace := core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: monNs}}
-	if err := r.kc.Delete(ctx, &monNamespace); client.IgnoreNotFound(err) != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/controllers/namespace/helpers.go
+++ b/pkg/controllers/namespace/helpers.go
@@ -102,6 +102,21 @@ func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namesp
 	return ctrl.Result{}, nil
 }
 
+// markCleanedUp stamps the cleaned-up marker on a "terminating" client-org namespace so a
+// later reconcile of the still-present namespace skips the (already done) teardown.
+func (r *ClientOrgReconciler) markCleanedUp(ctx context.Context, ns *core.Namespace) error {
+	_, err := cu.Patch(ctx, r.kc, ns, func(in client.Object) client.Object {
+		obj := in.(*core.Namespace)
+		if obj.Annotations == nil {
+			obj.Annotations = map[string]string{}
+		}
+		obj.Annotations[cleanedUpKey] = "true"
+
+		return obj
+	})
+	return err
+}
+
 // ensureFinalizer adds the shared Prometheus finalizer to the namespace.
 func (r *ClientOrgReconciler) ensureFinalizer(ctx context.Context, ns *core.Namespace) error {
 	vt, err := cu.CreateOrPatch(ctx, r.kc, ns, func(in client.Object, createOp bool) client.Object {

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// ClientOrgReconciler reconciles a GatewayConfig object
 type ClientOrgReconciler struct {
 	kc         client.Client
 	apiReader  client.Reader
@@ -65,11 +64,9 @@ func NewReconciler(kc client.Client, apiReader client.Reader, pc *prometheus.Cli
 const (
 	srcRefKey  = "meta.appcode.com/source"
 	srcHashKey = "meta.appcode.com/hash"
-	// cleanedUpKey marks a "terminating" client-org namespace whose backends and monitoring
-	// namespace have already been torn down, so cleanup runs once instead of on every reconcile.
+	// Guards the "terminating"-label teardown so it runs once, not on every reconcile.
 	cleanedUpKey = "meta.appcode.com/cleaned-up"
 
-	// cr created via monitoring-operator chart
 	crClientOrgMonitoring = "appscode:client-org:monitoring"
 	abClientOrgGrafana    = "grafana"
 	abClientOrgPerses     = "perses"
@@ -101,9 +98,8 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.handleDeletion(ctx, ns, clientOrgId)
 	}
 
-	// Path-B teardown: the client-org namespace itself is not deleted, its label is flipped
-	// to "terminating". Run the same cleanup once, guarded by a marker annotation so the
-	// lingering namespace does not re-fire backend Unregister POSTs on every reconcile.
+	// Teardown can also happen by flipping the label to "terminating" instead of deleting the
+	// namespace; run the same cleanup once, guarded by cleanedUpKey.
 	if ns.Labels[kmapi.ClientOrgKey] == "terminating" {
 		if ns.Annotations[cleanedUpKey] == "true" {
 			return ctrl.Result{}, nil
@@ -115,11 +111,10 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, r.markCleanedUp(ctx, &ns)
 	}
 
-	// The cached client lags the API server, and the ServiceAccount watch re-enqueues every
-	// client-org namespace on each trickster token refresh. A reconcile fired during teardown
-	// can therefore still observe a stale, live-looking namespace and recreate the copied
-	// dashboards that cleanup just removed. Re-read from the API server before (re)creating
-	// anything and bail out if the namespace is no longer an active client org.
+	// The cache lags the API server and the ServiceAccount watch re-enqueues every client-org
+	// namespace on each trickster token refresh, so a teardown-time reconcile can observe a
+	// stale, live-looking namespace and recreate dashboards cleanup just removed. Re-read from
+	// the API server and bail if it is no longer an active client org.
 	var fresh core.Namespace
 	if err := r.apiReader.Get(ctx, req.NamespacedName, &fresh); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -144,7 +139,6 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// confirm trickster rb registered
 	var promList monitoringv1.PrometheusList
 	if err := r.kc.List(ctx, &promList); err != nil {
 		return ctrl.Result{}, err
@@ -181,7 +175,6 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
 func (r *ClientOrgReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&core.Namespace{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -65,6 +65,9 @@ func NewReconciler(kc client.Client, apiReader client.Reader, pc *prometheus.Cli
 const (
 	srcRefKey  = "meta.appcode.com/source"
 	srcHashKey = "meta.appcode.com/hash"
+	// cleanedUpKey marks a "terminating" client-org namespace whose backends and monitoring
+	// namespace have already been torn down, so cleanup runs once instead of on every reconcile.
+	cleanedUpKey = "meta.appcode.com/cleaned-up"
 
 	// cr created via monitoring-operator chart
 	crClientOrgMonitoring = "appscode:client-org:monitoring"
@@ -78,7 +81,7 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if ns.Labels[kmapi.ClientOrgKey] == "" || ns.Labels[kmapi.ClientOrgKey] == "terminating" {
+	if ns.Labels[kmapi.ClientOrgKey] == "" {
 		return ctrl.Result{}, nil
 	}
 	clientOrgId := ns.Annotations[kmapi.AceOrgIDKey]
@@ -96,6 +99,20 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if ns.DeletionTimestamp != nil {
 		klog.Infof("client-org namespace %s (org %s) is terminating, unregistering backends", ns.Name, clientOrgId)
 		return r.handleDeletion(ctx, ns, clientOrgId)
+	}
+
+	// Path-B teardown: the client-org namespace itself is not deleted, its label is flipped
+	// to "terminating". Run the same cleanup once, guarded by a marker annotation so the
+	// lingering namespace does not re-fire backend Unregister POSTs on every reconcile.
+	if ns.Labels[kmapi.ClientOrgKey] == "terminating" {
+		if ns.Annotations[cleanedUpKey] == "true" {
+			return ctrl.Result{}, nil
+		}
+		klog.Infof("client-org namespace %s (org %s) label set to terminating, unregistering backends", ns.Name, clientOrgId)
+		if _, err := r.handleDeletion(ctx, ns, clientOrgId); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, r.markCleanedUp(ctx, &ns)
 	}
 
 	// The cached client lags the API server, and the ServiceAccount watch re-enqueues every
@@ -168,7 +185,8 @@ func (r *ClientOrgReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *ClientOrgReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&core.Namespace{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			return obj.GetLabels()[kmapi.ClientOrgKey] == "true" &&
+			v := obj.GetLabels()[kmapi.ClientOrgKey]
+			return (v == "true" || v == "terminating") &&
 				obj.GetLabels()[kmapi.ClientOrgMonitoringKey] != "false"
 		}))).
 		Watches(&core.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {

--- a/pkg/controllers/prometheus/client.go
+++ b/pkg/controllers/prometheus/client.go
@@ -310,12 +310,13 @@ func (c *Client) Unregister(ctx mona.PrometheusContext) error {
 	defer resp.Body.Close() // nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return apierrors.NewGenericServerResponse(
 			resp.StatusCode,
 			http.MethodDelete,
 			schema.GroupResource{Group: openviz.GroupName, Resource: openvizapi.ResourceGrafanaDatasources},
 			"",
-			"",
+			string(body),
 			0,
 			false,
 		)
@@ -361,12 +362,13 @@ func (c *Client) UnregisterPerses(ctx mona.PrometheusContext) error {
 	defer resp.Body.Close() // nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return apierrors.NewGenericServerResponse(
 			resp.StatusCode,
 			http.MethodDelete,
 			schema.GroupResource{Group: openviz.GroupName, Resource: openvizapi.ResourceGrafanaDatasources},
 			"",
-			"",
+			string(body),
 			0,
 			false,
 		)


### PR DESCRIPTION
## Problem

`org1-monitoring` and the grafana/perses backend registrations were only cleaned up when a client-org namespace was **actually deleted** (`deletionTimestamp` path → finalizer → `handleDeletion`). When teardown instead flips the label `ace.appscode.com/client-org` from `true` → `terminating` while the namespace persists (Path B), the controller bailed out early and never cleaned up — orphaning the monitoring namespace and backend registrations.

## Change

- **Predicate** (`SetupWithManager`): also enqueue namespaces whose `client-org` label is `terminating`, so the `true → terminating` update reaches Reconcile.
- **Reconcile**: treat the `terminating` label as a teardown trigger that runs the same `handleDeletion` cleanup (unregister grafana/perses, delete copied dashboards, delete the `*-monitoring` namespace, drop the finalizer).
- **Idempotency**: guard with a `meta.appcode.com/cleaned-up` marker annotation stamped via `cu.Patch`, so the lingering `terminating` namespace does not re-fire backend `Unregister` POSTs on every reconcile.

`handleDeletion` is reused unchanged; its finalizer removal is a harmless no-op on the non-deleting namespace. The real-deletion path (Path A) is untouched.

## Test

`go build ./...` passes.