### PR TITLE
Use Patch() instead of CreateOrPatch() where no creation is intended

### DIFF
--- a/pkg/controllers/namespace/backend.go
+++ b/pkg/controllers/namespace/backend.go
@@ -47,7 +47,7 @@ func (r *ClientOrgReconciler) appBindingExists(ctx context.Context, namespace, n
 }
 
 func (r *ClientOrgReconciler) setNamespaceMarker(ctx context.Context, monNamespace *core.Namespace, state string) error {
-	rbvt, err := cu.CreateOrPatch(ctx, r.kc, monNamespace, func(in client.Object, _ bool) client.Object {
+	rbvt, err := cu.Patch(ctx, r.kc, monNamespace, func(in client.Object) client.Object {
 		obj := in.(*core.Namespace)
 		if obj.Annotations == nil {
 			obj.Annotations = map[string]string{}

--- a/pkg/controllers/namespace/helpers.go
+++ b/pkg/controllers/namespace/helpers.go
@@ -83,7 +83,7 @@ func (r *ClientOrgReconciler) handleDeletion(ctx context.Context, ns core.Namesp
 		return ctrl.Result{}, err
 	}
 
-	vt, err := cu.CreateOrPatch(context.TODO(), r.kc, &ns, func(in client.Object, createOp bool) client.Object {
+	vt, err := cu.Patch(context.TODO(), r.kc, &ns, func(in client.Object) client.Object {
 		obj := in.(*core.Namespace)
 		obj.ObjectMeta = core_util.RemoveFinalizer(obj.ObjectMeta, mona.PrometheusKey)
 
@@ -112,7 +112,7 @@ func (r *ClientOrgReconciler) markCleanedUp(ctx context.Context, ns *core.Namesp
 }
 
 func (r *ClientOrgReconciler) ensureFinalizer(ctx context.Context, ns *core.Namespace) error {
-	vt, err := cu.CreateOrPatch(ctx, r.kc, ns, func(in client.Object, createOp bool) client.Object {
+	vt, err := cu.Patch(ctx, r.kc, ns, func(in client.Object) client.Object {
 		obj := in.(*core.Namespace)
 		obj.ObjectMeta = core_util.AddFinalizer(obj.ObjectMeta, mona.PrometheusKey)
 


### PR DESCRIPTION
The namespace finalizer add/remove (`ensureFinalizer`, `handleDeletion`) and the client-org registration marker (`setNamespaceMarker`) operate on namespaces that already exist, so a create path is never taken. Switch these three call sites from `cu.CreateOrPatch()` to `cu.Patch()`.

Call sites that genuinely create resources — AppBindings, auth secrets, the monitoring RoleBinding, and copied Grafana/Perses dashboards — are left on `CreateOrPatch()`.