### PR TITLE
Fix nil pointer panic when DashboardGroup request uses an object reference

### DIFF
--- a/pkg/registry/ui/dashboardgroup/storage.go
+++ b/pkg/registry/ui/dashboardgroup/storage.go
@@ -250,8 +250,8 @@ func (r *Storage) getDashboardLink(
 		if ns == "" {
 			return nil, fmt.Errorf("missing namespace for Dashboard")
 		}
-		err := r.kc.Get(ctx, client.ObjectKey{Namespace: ns, Name: req.Name}, &d)
-		if err != nil {
+		err := r.kc.Get(ctx, client.ObjectKey{Namespace: ns, Name: req.Name}, &persesDashboard)
+		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 	} else if req.Title != "" {
@@ -362,15 +362,17 @@ func (r *Storage) getDashboardLink(
 	}
 
 	var pDashboard v1.Dashboard
-	err = json.Unmarshal(persesDashboard.Spec.Model.Raw, &pDashboard)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal model for PersesDashboard %s/%s, reason: %v", d.Namespace, d.Name, err)
+	if persesDashboard.Spec.Model != nil {
+		if err := json.Unmarshal(persesDashboard.Spec.Model.Raw, &pDashboard); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal model for PersesDashboard %s/%s, reason: %v", persesDashboard.Namespace, persesDashboard.Name, err)
+		}
 	}
 
 	var persesConfig openvizapi.PersesConfiguration
-	err = json.Unmarshal(ps.Spec.Parameters.Raw, &persesConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal PersesConfiguration %s/%s, reason: %v", d.Namespace, d.Name, err)
+	if ps.Spec.Parameters != nil {
+		if err := json.Unmarshal(ps.Spec.Parameters.Raw, &persesConfig); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal PersesConfiguration %s/%s, reason: %v", ps.Namespace, ps.Name, err)
+		}
 	}
 
 	resp := &uiapi.DashboardResponse{


### PR DESCRIPTION
`kubectl create -f dashboardgroup.yaml` failed with:

```
Error from server (ServiceUnavailable): the server is currently unable to handle the request (post dashboardgroups.ui.openviz.dev)
```

The APIService was `Available=True`; the 503 was the aggregator surfacing a panic in the backend:

```
E0821 09:03:31 wrap.go:57 "apiserver panic'd" method="POST" URI="/apis/ui.openviz.dev/v1alpha1/dashboardgroups?..."
http2: panic serving: runtime error: invalid memory address or nil pointer dereference
  dashboardgroup.(*Storage).getDashboardLink ... storage.go:365
  dashboardgroup.(*Storage).Create ... storage.go:118
```

## Cause

The `PersesDashboard` lookup in `getDashboardLink` was a copy of the `GrafanaDashboard` one and, on the `req.ObjectReference` path, fetched into `&d` (the `GrafanaDashboard`) instead of `&persesDashboard`. `persesDashboard` therefore stayed zero-valued and `json.Unmarshal(persesDashboard.Spec.Model.Raw, ...)` dereferenced a nil `RawExtension`.

Only requests that set `namespace`/`name` hit this; the title-only path assigns `persesDashboard` from the List result.

## Fix

- Fetch into `&persesDashboard`, tolerating `NotFound` so clusters with no matching `PersesDashboard` keep working.
- Guard `persesDashboard.Spec.Model` and `ps.Spec.Parameters` before unmarshalling.
- Error messages for those two unmarshals named `d` instead of the Perses object; corrected.

## Not addressed (pre-existing, outside this panic)

- The title path returns `NotFound` when no `PersesDashboard` matches the title, so a Grafana-only cluster fails there.
- `perses.GetPerses` with a nil ref falls back to the default-Perses AppBinding and hard-errors when none exists.
